### PR TITLE
Add PostgreSQL quiz support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,6 @@ dist
 # Vite logs files
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+
+# Windows null device output redirected incorrectly
+nul

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "buffer": "^6.0.3",
+        "pg-mem": "^3.0.5",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.8.0",
@@ -5061,6 +5063,26 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/batch": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
@@ -5244,6 +5266,30 @@
       "license": "Apache-2.0",
       "dependencies": {
         "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/buffer-from": {
@@ -6525,6 +6571,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/discontinuous-range": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
+      "integrity": "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ==",
+      "license": "MIT"
     },
     "node_modules/dlv": {
       "version": "1.1.3",
@@ -8318,6 +8370,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
+      "license": "MIT"
+    },
     "node_modules/functions-have-names": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
@@ -9008,6 +9066,26 @@
         "node": ">=4"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -9026,6 +9104,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
       }
+    },
+    "node_modules/immutable": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.7.tgz",
+      "integrity": "sha512-1hqclzwYwjRDFLjcFxOM5AYkkG0rpFPpr1RLPMEuGczoS7YA8gLhy8SWXYRAA/XwfEHpfo3cw5JGioS32fnMRw==",
+      "license": "MIT"
     },
     "node_modules/import-fresh": {
       "version": "3.3.1",
@@ -10801,6 +10885,25 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "license": "MIT"
     },
+    "node_modules/json-stable-stringify": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz",
+      "integrity": "sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "isarray": "^2.0.5",
+        "jsonify": "^0.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -10829,6 +10932,15 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+      "license": "Public Domain",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/jsonpath": {
@@ -11314,6 +11426,21 @@
         "mkdirp": "bin/cmd.js"
       }
     },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/moo": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.2.tgz",
+      "integrity": "sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -11372,6 +11499,34 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
       "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
+      "license": "MIT"
+    },
+    "node_modules/nearley": {
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.20.1.tgz",
+      "integrity": "sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^2.19.0",
+        "moo": "^0.5.0",
+        "railroad-diagrams": "^1.0.0",
+        "randexp": "0.4.6"
+      },
+      "bin": {
+        "nearley-railroad": "bin/nearley-railroad.js",
+        "nearley-test": "bin/nearley-test.js",
+        "nearley-unparse": "bin/nearley-unparse.js",
+        "nearleyc": "bin/nearleyc.js"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://nearley.js.org/#give-to-nearley"
+      }
+    },
+    "node_modules/nearley/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "license": "MIT"
     },
     "node_modules/negotiator": {
@@ -11922,6 +12077,101 @@
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
       "license": "MIT"
+    },
+    "node_modules/pg-mem": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/pg-mem/-/pg-mem-3.0.5.tgz",
+      "integrity": "sha512-Bh8xHD6u/wUXCoyFE2vyRs5pgaKbqjWFQowKDlbKWCiF0vOlo2A0PZdiUxmf2PKgb6Vb6C7gwAlA7jKvsfDHZA==",
+      "license": "MIT",
+      "dependencies": {
+        "functional-red-black-tree": "^1.0.1",
+        "immutable": "^4.3.4",
+        "json-stable-stringify": "^1.0.1",
+        "lru-cache": "^6.0.0",
+        "moment": "^2.27.0",
+        "object-hash": "^2.0.3",
+        "pgsql-ast-parser": "^12.0.1"
+      },
+      "peerDependencies": {
+        "@mikro-orm/core": ">=4.5.3",
+        "@mikro-orm/postgresql": ">=4.5.3",
+        "knex": ">=0.20",
+        "kysely": ">=0.26",
+        "pg-promise": ">=10.8.7",
+        "pg-server": "^0.1.5",
+        "postgres": "^3.4.4",
+        "slonik": ">=23.0.1",
+        "typeorm": ">=0.2.29"
+      },
+      "peerDependenciesMeta": {
+        "@mikro-orm/core": {
+          "optional": true
+        },
+        "@mikro-orm/postgresql": {
+          "optional": true
+        },
+        "knex": {
+          "optional": true
+        },
+        "kysely": {
+          "optional": true
+        },
+        "mikro-orm": {
+          "optional": true
+        },
+        "pg-promise": {
+          "optional": true
+        },
+        "pg-server": {
+          "optional": true
+        },
+        "postgres": {
+          "optional": true
+        },
+        "slonik": {
+          "optional": true
+        },
+        "typeorm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-mem/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pg-mem/node_modules/object-hash": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
+      "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/pg-mem/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
+    },
+    "node_modules/pgsql-ast-parser": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/pgsql-ast-parser/-/pgsql-ast-parser-12.0.1.tgz",
+      "integrity": "sha512-pe8C6Zh5MsS+o38WlSu18NhrTjAv1UNMeDTs2/Km2ZReZdYBYtwtbWGZKK2BM2izv5CrQpbmP0oI10wvHOwv4A==",
+      "license": "MIT",
+      "dependencies": {
+        "moo": "^0.5.1",
+        "nearley": "^2.19.5"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -13553,6 +13803,25 @@
         "performance-now": "^2.1.0"
       }
     },
+    "node_modules/railroad-diagrams": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
+      "integrity": "sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A==",
+      "license": "CC0-1.0"
+    },
+    "node_modules/randexp": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
+      "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "discontinuous-range": "1.0.0",
+        "ret": "~0.1.10"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -14197,6 +14466,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12"
       }
     },
     "node_modules/retry": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "regex-quiz-app",
+  "name": "programming-quiz-app",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "regex-quiz-app",
+      "name": "programming-quiz-app",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
@@ -16203,9 +16203,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "license": "Apache-2.0",
       "peer": true,
       "bin": {
@@ -16213,7 +16213,7 @@
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=4.2.0"
       }
     },
     "node_modules/unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "eject": "react-scripts eject"
   },
   "dependencies": {
+    "buffer": "^6.0.3",
+    "pg-mem": "^3.0.5",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.8.0",
@@ -27,7 +29,12 @@
       "last 1 safari version"
     ]
   },
-  "keywords": ["programming", "quiz", "react", "javascript"],
+  "keywords": [
+    "programming",
+    "quiz",
+    "react",
+    "javascript"
+  ],
   "author": "",
   "license": "MIT"
 }

--- a/src/App.css
+++ b/src/App.css
@@ -674,6 +674,19 @@
   font-size: 1.2rem;
   min-width: 40px;
   color: #666;
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.attempt-badge {
+  font-size: 0.7rem;
+  font-weight: normal;
+  background: #ffc107;
+  color: #212529;
+  padding: 2px 6px;
+  border-radius: 10px;
+  white-space: nowrap;
 }
 
 .answer-content {

--- a/src/App.css
+++ b/src/App.css
@@ -412,6 +412,93 @@
   margin: 0;
 }
 
+.sql-analysis {
+  background: #f8f9fa;
+  border: 1px solid #dee2e6;
+}
+
+.sql-analysis h4 {
+  color: #495057;
+  margin-bottom: 20px;
+  font-size: 1.1rem;
+}
+
+.analysis-section {
+  margin-bottom: 15px;
+  padding-bottom: 15px;
+  border-bottom: 1px solid #e9ecef;
+}
+
+.analysis-section:last-child {
+  border-bottom: none;
+  margin-bottom: 0;
+  padding-bottom: 0;
+}
+
+.analysis-section strong {
+  display: block;
+  color: #495057;
+  margin-bottom: 8px;
+  font-size: 0.95rem;
+}
+
+.status-badge {
+  display: inline-block;
+  padding: 6px 12px;
+  border-radius: 15px;
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.status-badge.valid {
+  background: #d4edda;
+  color: #155724;
+}
+
+.status-badge.invalid {
+  background: #fff3cd;
+  color: #856404;
+}
+
+.keyword-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.keyword-tag {
+  background: #007bff;
+  color: white;
+  padding: 4px 10px;
+  border-radius: 12px;
+  font-size: 0.85rem;
+  font-weight: 500;
+  font-family: monospace;
+}
+
+.analysis-section.errors ul {
+  margin: 0;
+  padding-left: 20px;
+  color: #856404;
+}
+
+.analysis-section.errors li {
+  margin-bottom: 5px;
+}
+
+.normalized-sql {
+  display: block;
+  background: #343a40;
+  color: #00ff00;
+  padding: 12px;
+  border-radius: 6px;
+  font-family: 'Courier New', monospace;
+  font-size: 0.9rem;
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
 .results {
   max-width: 900px;
   margin: 0 auto;

--- a/src/App.css
+++ b/src/App.css
@@ -23,6 +23,56 @@
   margin: 0 auto;
 }
 
+.quiz-type-selection {
+  margin-bottom: 50px;
+}
+
+.quiz-type-selection h2 {
+  color: white;
+  margin-bottom: 25px;
+  font-size: 2rem;
+}
+
+.quiz-type-buttons {
+  display: flex;
+  justify-content: center;
+  gap: 20px;
+  flex-wrap: wrap;
+}
+
+.quiz-type-btn {
+  padding: 15px 40px;
+  font-size: 1.1rem;
+  font-weight: 600;
+  border: 3px solid white;
+  background: rgba(255, 255, 255, 0.1);
+  color: white;
+  border-radius: 50px;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  backdrop-filter: blur(10px);
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+
+.quiz-type-btn:hover {
+  background: rgba(255, 255, 255, 0.2);
+  transform: translateY(-2px);
+  box-shadow: 0 5px 15px rgba(0, 0, 0, 0.2);
+}
+
+.quiz-type-btn.active {
+  background: white;
+  color: #667eea;
+  box-shadow: 0 5px 20px rgba(255, 255, 255, 0.3);
+  transform: scale(1.05);
+}
+
+.quiz-type-btn.active:hover {
+  background: white;
+  transform: scale(1.05) translateY(-2px);
+}
+
 .difficulty-selection h2 {
   color: white;
   margin-bottom: 40px;
@@ -229,6 +279,30 @@
   font-size: 1rem;
   font-family: monospace;
   outline: none;
+}
+
+#sql-input {
+  width: 100%;
+  border: 2px solid #e9ecef;
+  background: #f8f9fa;
+  border-radius: 8px;
+  padding: 15px;
+  font-size: 1rem;
+  font-family: monospace;
+  outline: none;
+  resize: vertical;
+  min-height: 100px;
+  transition: border-color 0.3s ease;
+  line-height: 1.5;
+}
+
+#sql-input:focus {
+  border-color: #007bff;
+  background: #ffffff;
+}
+
+#sql-input::placeholder {
+  color: #adb5bd;
 }
 
 .feedback {

--- a/src/App.css
+++ b/src/App.css
@@ -499,6 +499,62 @@
   word-break: break-all;
 }
 
+.sql-results-table {
+  overflow-x: auto;
+  margin-top: 10px;
+}
+
+.sql-results-table table {
+  width: 100%;
+  border-collapse: collapse;
+  background: white;
+  border: 1px solid #dee2e6;
+}
+
+.sql-results-table th {
+  background: #007bff;
+  color: white;
+  padding: 10px;
+  text-align: left;
+  font-weight: 600;
+  border: 1px solid #0056b3;
+}
+
+.sql-results-table td {
+  padding: 8px 10px;
+  border: 1px solid #dee2e6;
+  font-family: monospace;
+}
+
+.sql-results-table tbody tr:nth-child(even) {
+  background: #f8f9fa;
+}
+
+.sql-results-table tbody tr:hover {
+  background: #e9ecef;
+}
+
+.sql-results-table td em {
+  color: #6c757d;
+  font-style: italic;
+}
+
+.sql-error {
+  background: #fff3cd;
+  border: 1px solid #ffeaa7;
+  color: #856404;
+  padding: 12px;
+  border-radius: 6px;
+  font-family: monospace;
+  margin-top: 8px;
+}
+
+.no-results {
+  color: #6c757d;
+  font-style: italic;
+  margin: 10px 0;
+}
+
 .results {
   max-width: 900px;
   margin: 0 auto;

--- a/src/App.js
+++ b/src/App.js
@@ -10,7 +10,7 @@ function App() {
     <div className="App">
       <Routes>
         <Route path="/" element={<Home />} />
-        <Route path="/quiz/:difficulty" element={<Quiz />} />
+        <Route path="/quiz/:quizType/:difficulty" element={<Quiz />} />
         <Route path="/results" element={<Results />} />
       </Routes>
     </div>

--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -1,44 +1,76 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
 
 function Home() {
+  const [quizType, setQuizType] = useState('regex');
+
   return (
     <div className="home">
       <header className="home-header">
-        <h1>Regex Quiz Challenge</h1>
-        <p>Test your regular expression skills with challenges of varying difficulty!</p>
+        <h1>Programming Quiz Challenge</h1>
+        <p>Test your programming skills with challenges of varying difficulty!</p>
       </header>
-      
+
+      <div className="quiz-type-selection">
+        <h2>Choose Your Quiz Type</h2>
+        <div className="quiz-type-buttons">
+          <button
+            className={`quiz-type-btn ${quizType === 'regex' ? 'active' : ''}`}
+            onClick={() => setQuizType('regex')}
+          >
+            Regex
+          </button>
+          <button
+            className={`quiz-type-btn ${quizType === 'postgresql' ? 'active' : ''}`}
+            onClick={() => setQuizType('postgresql')}
+          >
+            PostgreSQL
+          </button>
+        </div>
+      </div>
+
       <div className="difficulty-selection">
         <h2>Choose Your Challenge Level</h2>
-        
+
         <div className="difficulty-cards">
-          <Link to="/quiz/easy" className="difficulty-card easy">
+          <Link to={`/quiz/${quizType}/easy`} className="difficulty-card easy">
             <h3>Easy</h3>
-            <p>Basic regex patterns and character classes</p>
+            <p>
+              {quizType === 'regex'
+                ? 'Basic regex patterns and character classes'
+                : 'Basic SELECT queries and simple WHERE clauses'}
+            </p>
             <span className="challenge-count">5 challenges</span>
           </Link>
-          
-          <Link to="/quiz/medium" className="difficulty-card medium">
+
+          <Link to={`/quiz/${quizType}/medium`} className="difficulty-card medium">
             <h3>Medium</h3>
-            <p>Quantifiers, word boundaries, and common patterns</p>
+            <p>
+              {quizType === 'regex'
+                ? 'Quantifiers, word boundaries, and common patterns'
+                : 'JOINs, GROUP BY, and aggregate functions'}
+            </p>
             <span className="challenge-count">5 challenges</span>
           </Link>
-          
-          <Link to="/quiz/hard" className="difficulty-card hard">
+
+          <Link to={`/quiz/${quizType}/hard`} className="difficulty-card hard">
             <h3>Hard</h3>
-            <p>Advanced patterns, lookaheads, and complex matching</p>
+            <p>
+              {quizType === 'regex'
+                ? 'Advanced patterns, lookaheads, and complex matching'
+                : 'Subqueries, CTEs, and window functions'}
+            </p>
             <span className="challenge-count">5 challenges</span>
           </Link>
         </div>
       </div>
-      
+
       <div className="instructions">
         <h3>How to Play</h3>
         <ul>
-          <li>Choose a difficulty level above</li>
-          <li>Write regex patterns to match the given requirements</li>
-          <li>Test your patterns against provided strings</li>
+          <li>Choose a quiz type above (Regex or PostgreSQL)</li>
+          <li>Select a difficulty level</li>
+          <li>Write {quizType === 'regex' ? 'regex patterns' : 'SQL queries'} to solve the challenges</li>
           <li>Get instant feedback and hints if needed</li>
           <li>Complete all challenges to see your score!</li>
         </ul>

--- a/src/components/Results.js
+++ b/src/components/Results.js
@@ -3,7 +3,7 @@ import { Link, useLocation } from 'react-router-dom';
 
 function Results() {
   const location = useLocation();
-  const { score, total, difficulty, answers } = location.state || {};
+  const { score, total, difficulty, answers, questionStatus } = location.state || {};
 
   if (!location.state) {
     return (
@@ -14,6 +14,9 @@ function Results() {
     );
   }
 
+  // Calculate total attempts (including re-submissions)
+  const totalAttempts = answers ? answers.length : total;
+  // Score is based on questions answered correctly on first attempt
   const percentage = Math.round((score / total) * 100);
   
   const getGrade = () => {
@@ -42,6 +45,7 @@ function Results() {
         </div>
         <p className="difficulty-completed">
           {difficulty.charAt(0).toUpperCase() + difficulty.slice(1)} Level Completed
+          {totalAttempts > total && <span> ({total} questions, {totalAttempts} total attempts)</span>}
         </p>
       </div>
 
@@ -50,7 +54,10 @@ function Results() {
         <div className="answers-review">
           {answers.map((answer, index) => (
             <div key={index} className={`answer-item ${answer.correct ? 'correct' : 'incorrect'}`}>
-              <div className="question-number">Q{index + 1}</div>
+              <div className="question-number">
+                Q{answer.questionNumber}
+                {answer.attemptNumber > 1 && <span className="attempt-badge">Attempt {answer.attemptNumber}</span>}
+              </div>
               <div className="answer-content">
                 <h4>{answer.question}</h4>
                 <div className="answer-comparison">

--- a/src/data/challenges.js
+++ b/src/data/challenges.js
@@ -5,6 +5,18 @@ export const postgresqlChallenges = {
       question: "Select all columns from a table",
       description: "Write a SQL query to select all columns from a table named 'users'",
       testString: "users table: id, name, email, age",
+      setupSQL: `
+        CREATE TABLE users (
+          id SERIAL PRIMARY KEY,
+          name VARCHAR(100),
+          email VARCHAR(100),
+          age INTEGER
+        );
+        INSERT INTO users (name, email, age) VALUES
+          ('Alice', 'alice@example.com', 25),
+          ('Bob', 'bob@example.com', 30),
+          ('Charlie', 'charlie@example.com', 17);
+      `,
       correctAnswer: "SELECT * FROM users",
       hints: ["Use SELECT *", "FROM specifies the table", "Don't forget the semicolon is optional"]
     },
@@ -13,6 +25,18 @@ export const postgresqlChallenges = {
       question: "Select specific columns",
       description: "Write a SQL query to select only 'name' and 'email' columns from 'users' table",
       testString: "users table: id, name, email, age",
+      setupSQL: `
+        CREATE TABLE users (
+          id SERIAL PRIMARY KEY,
+          name VARCHAR(100),
+          email VARCHAR(100),
+          age INTEGER
+        );
+        INSERT INTO users (name, email, age) VALUES
+          ('Alice', 'alice@example.com', 25),
+          ('Bob', 'bob@example.com', 30),
+          ('Charlie', 'charlie@example.com', 17);
+      `,
       correctAnswer: "SELECT name, email FROM users",
       hints: ["List columns separated by commas", "Use FROM to specify table", "Order doesn't matter for correctness"]
     },
@@ -21,6 +45,18 @@ export const postgresqlChallenges = {
       question: "Filter with WHERE clause",
       description: "Write a SQL query to select all users where age is greater than 18",
       testString: "users table: id, name, email, age",
+      setupSQL: `
+        CREATE TABLE users (
+          id SERIAL PRIMARY KEY,
+          name VARCHAR(100),
+          email VARCHAR(100),
+          age INTEGER
+        );
+        INSERT INTO users (name, email, age) VALUES
+          ('Alice', 'alice@example.com', 25),
+          ('Bob', 'bob@example.com', 30),
+          ('Charlie', 'charlie@example.com', 17);
+      `,
       correctAnswer: "SELECT * FROM users WHERE age > 18",
       hints: ["Use WHERE clause for filtering", "Use > for greater than", "Place WHERE after FROM"]
     },
@@ -29,6 +65,18 @@ export const postgresqlChallenges = {
       question: "Count rows",
       description: "Write a SQL query to count the total number of users",
       testString: "users table: id, name, email, age",
+      setupSQL: `
+        CREATE TABLE users (
+          id SERIAL PRIMARY KEY,
+          name VARCHAR(100),
+          email VARCHAR(100),
+          age INTEGER
+        );
+        INSERT INTO users (name, email, age) VALUES
+          ('Alice', 'alice@example.com', 25),
+          ('Bob', 'bob@example.com', 30),
+          ('Charlie', 'charlie@example.com', 17);
+      `,
       correctAnswer: "SELECT COUNT(*) FROM users",
       hints: ["Use COUNT() function", "COUNT(*) counts all rows", "No WHERE clause needed"]
     },
@@ -37,6 +85,18 @@ export const postgresqlChallenges = {
       question: "Order results",
       description: "Write a SQL query to select all users ordered by name in ascending order",
       testString: "users table: id, name, email, age",
+      setupSQL: `
+        CREATE TABLE users (
+          id SERIAL PRIMARY KEY,
+          name VARCHAR(100),
+          email VARCHAR(100),
+          age INTEGER
+        );
+        INSERT INTO users (name, email, age) VALUES
+          ('Alice', 'alice@example.com', 25),
+          ('Bob', 'bob@example.com', 30),
+          ('Charlie', 'charlie@example.com', 17);
+      `,
       correctAnswer: "SELECT * FROM users ORDER BY name ASC",
       hints: ["Use ORDER BY clause", "ASC means ascending", "Place ORDER BY at the end"]
     }
@@ -47,6 +107,19 @@ export const postgresqlChallenges = {
       question: "Join two tables",
       description: "Write a SQL query to join 'users' and 'orders' tables on user_id",
       testString: "users(id, name) orders(id, user_id, total)",
+      setupSQL: `
+        CREATE TABLE users (
+          id SERIAL PRIMARY KEY,
+          name VARCHAR(100)
+        );
+        CREATE TABLE orders (
+          id SERIAL PRIMARY KEY,
+          user_id INTEGER,
+          total DECIMAL(10, 2)
+        );
+        INSERT INTO users (name) VALUES ('Alice'), ('Bob'), ('Charlie');
+        INSERT INTO orders (user_id, total) VALUES (1, 100.00), (2, 150.00), (1, 75.50);
+      `,
       correctAnswer: "SELECT * FROM users JOIN orders ON users.id = orders.user_id",
       hints: ["Use JOIN keyword", "ON specifies join condition", "Match primary and foreign keys"]
     },
@@ -55,6 +128,15 @@ export const postgresqlChallenges = {
       question: "Group by and aggregate",
       description: "Write a SQL query to count orders per user, showing user_id and count",
       testString: "orders table: id, user_id, total, created_at",
+      setupSQL: `
+        CREATE TABLE orders (
+          id SERIAL PRIMARY KEY,
+          user_id INTEGER,
+          total DECIMAL(10, 2),
+          created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        );
+        INSERT INTO orders (user_id, total) VALUES (1, 100.00), (2, 150.00), (1, 75.50), (3, 200.00), (1, 50.00);
+      `,
       correctAnswer: "SELECT user_id, COUNT(*) FROM orders GROUP BY user_id",
       hints: ["Use GROUP BY for aggregation", "COUNT(*) for counting", "Non-aggregated columns must be in GROUP BY"]
     },
@@ -63,6 +145,18 @@ export const postgresqlChallenges = {
       question: "Filter with IN operator",
       description: "Write a SQL query to select users where status is 'active' or 'pending'",
       testString: "users table: id, name, status",
+      setupSQL: `
+        CREATE TABLE users (
+          id SERIAL PRIMARY KEY,
+          name VARCHAR(100),
+          status VARCHAR(20)
+        );
+        INSERT INTO users (name, status) VALUES
+          ('Alice', 'active'),
+          ('Bob', 'inactive'),
+          ('Charlie', 'pending'),
+          ('David', 'active');
+      `,
       correctAnswer: "SELECT * FROM users WHERE status IN ('active', 'pending')",
       hints: ["Use IN operator", "List values in parentheses", "Strings need quotes"]
     },
@@ -71,6 +165,17 @@ export const postgresqlChallenges = {
       question: "Use LIKE for pattern matching",
       description: "Write a SQL query to find users whose email ends with '@gmail.com'",
       testString: "users table: id, name, email",
+      setupSQL: `
+        CREATE TABLE users (
+          id SERIAL PRIMARY KEY,
+          name VARCHAR(100),
+          email VARCHAR(100)
+        );
+        INSERT INTO users (name, email) VALUES
+          ('Alice', 'alice@gmail.com'),
+          ('Bob', 'bob@yahoo.com'),
+          ('Charlie', 'charlie@gmail.com');
+      `,
       correctAnswer: "SELECT * FROM users WHERE email LIKE '%@gmail.com'",
       hints: ["Use LIKE operator", "% is a wildcard", "Place % at the start to match ending"]
     },
@@ -79,6 +184,20 @@ export const postgresqlChallenges = {
       question: "Limit results",
       description: "Write a SQL query to select the first 10 users ordered by created_at",
       testString: "users table: id, name, email, created_at",
+      setupSQL: `
+        CREATE TABLE users (
+          id SERIAL PRIMARY KEY,
+          name VARCHAR(100),
+          email VARCHAR(100),
+          created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        );
+        INSERT INTO users (name, email) VALUES
+          ('User1', 'user1@example.com'),
+          ('User2', 'user2@example.com'),
+          ('User3', 'user3@example.com'),
+          ('User4', 'user4@example.com'),
+          ('User5', 'user5@example.com');
+      `,
       correctAnswer: "SELECT * FROM users ORDER BY created_at LIMIT 10",
       hints: ["Use LIMIT clause", "ORDER BY comes before LIMIT", "LIMIT goes at the end"]
     }
@@ -87,9 +206,25 @@ export const postgresqlChallenges = {
     {
       id: 11,
       question: "Subquery in WHERE",
-      description: "Write a SQL query to find users who have placed more than 5 orders",
+      description: "Write a SQL query to find users who have placed more than 2 orders",
       testString: "users(id, name) orders(id, user_id, total)",
-      correctAnswer: "SELECT * FROM users WHERE id IN (SELECT user_id FROM orders GROUP BY user_id HAVING COUNT(*) > 5)",
+      setupSQL: `
+        CREATE TABLE users (
+          id SERIAL PRIMARY KEY,
+          name VARCHAR(100)
+        );
+        CREATE TABLE orders (
+          id SERIAL PRIMARY KEY,
+          user_id INTEGER,
+          total DECIMAL(10, 2)
+        );
+        INSERT INTO users (name) VALUES ('Alice'), ('Bob'), ('Charlie'), ('David');
+        INSERT INTO orders (user_id, total) VALUES
+          (1, 100.00), (1, 150.00), (1, 75.50),
+          (2, 200.00), (2, 50.00),
+          (3, 300.00);
+      `,
+      correctAnswer: "SELECT * FROM users WHERE id IN (SELECT user_id FROM orders GROUP BY user_id HAVING COUNT(*) > 2)",
       hints: ["Use subquery with IN", "GROUP BY user_id in subquery", "Use HAVING for aggregate conditions"]
     },
     {
@@ -97,31 +232,73 @@ export const postgresqlChallenges = {
       question: "Left join with condition",
       description: "Write a SQL query to show all users and their orders (if any), including users with no orders",
       testString: "users(id, name) orders(id, user_id, total)",
+      setupSQL: `
+        CREATE TABLE users (
+          id SERIAL PRIMARY KEY,
+          name VARCHAR(100)
+        );
+        CREATE TABLE orders (
+          id SERIAL PRIMARY KEY,
+          user_id INTEGER,
+          total DECIMAL(10, 2)
+        );
+        INSERT INTO users (name) VALUES ('Alice'), ('Bob'), ('Charlie');
+        INSERT INTO orders (user_id, total) VALUES (1, 100.00), (2, 150.00);
+      `,
       correctAnswer: "SELECT * FROM users LEFT JOIN orders ON users.id = orders.user_id",
       hints: ["Use LEFT JOIN", "LEFT JOIN includes all rows from left table", "ON specifies join condition"]
     },
     {
       id: 13,
       question: "Window function",
-      description: "Write a SQL query to show each order with a running total of amounts using ROW_NUMBER",
+      description: "Write a SQL query to show each order with a row number using ROW_NUMBER",
       testString: "orders table: id, user_id, amount, created_at",
+      setupSQL: `
+        CREATE TABLE orders (
+          id SERIAL PRIMARY KEY,
+          user_id INTEGER,
+          amount DECIMAL(10, 2),
+          created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        );
+        INSERT INTO orders (user_id, amount) VALUES (1, 100.00), (2, 150.00), (1, 75.50);
+      `,
       correctAnswer: "SELECT *, ROW_NUMBER() OVER (ORDER BY created_at) FROM orders",
       hints: ["Use ROW_NUMBER() window function", "OVER clause defines the window", "ORDER BY inside OVER"]
     },
     {
       id: 14,
       question: "Common Table Expression (CTE)",
-      description: "Write a SQL query using WITH to create a CTE named 'recent_orders' for orders from last 30 days, then select from it",
+      description: "Write a SQL query using WITH to create a CTE named 'high_orders' for orders over 100, then select from it",
       testString: "orders table: id, user_id, total, created_at",
-      correctAnswer: "WITH recent_orders AS (SELECT * FROM orders WHERE created_at > CURRENT_DATE - INTERVAL '30 days') SELECT * FROM recent_orders",
+      setupSQL: `
+        CREATE TABLE orders (
+          id SERIAL PRIMARY KEY,
+          user_id INTEGER,
+          total DECIMAL(10, 2),
+          created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        );
+        INSERT INTO orders (user_id, total) VALUES (1, 150.00), (2, 50.00), (1, 200.00), (3, 75.00);
+      `,
+      correctAnswer: "WITH high_orders AS (SELECT * FROM orders WHERE total > 100) SELECT * FROM high_orders",
       hints: ["Start with WITH", "Name the CTE before AS", "Select from CTE name at the end"]
     },
     {
       id: 15,
       question: "Complex aggregation",
-      description: "Write a SQL query to find the average order total per user, only for users with more than 3 orders",
+      description: "Write a SQL query to find the average order total per user, only for users with more than 1 order",
       testString: "orders table: id, user_id, total",
-      correctAnswer: "SELECT user_id, AVG(total) FROM orders GROUP BY user_id HAVING COUNT(*) > 3",
+      setupSQL: `
+        CREATE TABLE orders (
+          id SERIAL PRIMARY KEY,
+          user_id INTEGER,
+          total DECIMAL(10, 2)
+        );
+        INSERT INTO orders (user_id, total) VALUES
+          (1, 100.00), (1, 150.00), (1, 75.50),
+          (2, 200.00), (2, 50.00),
+          (3, 300.00);
+      `,
+      correctAnswer: "SELECT user_id, AVG(total) FROM orders GROUP BY user_id HAVING COUNT(*) > 1",
       hints: ["Use AVG() for average", "GROUP BY user_id", "HAVING filters groups after aggregation"]
     }
   ]

--- a/src/data/challenges.js
+++ b/src/data/challenges.js
@@ -1,3 +1,132 @@
+export const postgresqlChallenges = {
+  easy: [
+    {
+      id: 1,
+      question: "Select all columns from a table",
+      description: "Write a SQL query to select all columns from a table named 'users'",
+      testString: "users table: id, name, email, age",
+      correctAnswer: "SELECT * FROM users",
+      hints: ["Use SELECT *", "FROM specifies the table", "Don't forget the semicolon is optional"]
+    },
+    {
+      id: 2,
+      question: "Select specific columns",
+      description: "Write a SQL query to select only 'name' and 'email' columns from 'users' table",
+      testString: "users table: id, name, email, age",
+      correctAnswer: "SELECT name, email FROM users",
+      hints: ["List columns separated by commas", "Use FROM to specify table", "Order doesn't matter for correctness"]
+    },
+    {
+      id: 3,
+      question: "Filter with WHERE clause",
+      description: "Write a SQL query to select all users where age is greater than 18",
+      testString: "users table: id, name, email, age",
+      correctAnswer: "SELECT * FROM users WHERE age > 18",
+      hints: ["Use WHERE clause for filtering", "Use > for greater than", "Place WHERE after FROM"]
+    },
+    {
+      id: 4,
+      question: "Count rows",
+      description: "Write a SQL query to count the total number of users",
+      testString: "users table: id, name, email, age",
+      correctAnswer: "SELECT COUNT(*) FROM users",
+      hints: ["Use COUNT() function", "COUNT(*) counts all rows", "No WHERE clause needed"]
+    },
+    {
+      id: 5,
+      question: "Order results",
+      description: "Write a SQL query to select all users ordered by name in ascending order",
+      testString: "users table: id, name, email, age",
+      correctAnswer: "SELECT * FROM users ORDER BY name ASC",
+      hints: ["Use ORDER BY clause", "ASC means ascending", "Place ORDER BY at the end"]
+    }
+  ],
+  medium: [
+    {
+      id: 6,
+      question: "Join two tables",
+      description: "Write a SQL query to join 'users' and 'orders' tables on user_id",
+      testString: "users(id, name) orders(id, user_id, total)",
+      correctAnswer: "SELECT * FROM users JOIN orders ON users.id = orders.user_id",
+      hints: ["Use JOIN keyword", "ON specifies join condition", "Match primary and foreign keys"]
+    },
+    {
+      id: 7,
+      question: "Group by and aggregate",
+      description: "Write a SQL query to count orders per user, showing user_id and count",
+      testString: "orders table: id, user_id, total, created_at",
+      correctAnswer: "SELECT user_id, COUNT(*) FROM orders GROUP BY user_id",
+      hints: ["Use GROUP BY for aggregation", "COUNT(*) for counting", "Non-aggregated columns must be in GROUP BY"]
+    },
+    {
+      id: 8,
+      question: "Filter with IN operator",
+      description: "Write a SQL query to select users where status is 'active' or 'pending'",
+      testString: "users table: id, name, status",
+      correctAnswer: "SELECT * FROM users WHERE status IN ('active', 'pending')",
+      hints: ["Use IN operator", "List values in parentheses", "Strings need quotes"]
+    },
+    {
+      id: 9,
+      question: "Use LIKE for pattern matching",
+      description: "Write a SQL query to find users whose email ends with '@gmail.com'",
+      testString: "users table: id, name, email",
+      correctAnswer: "SELECT * FROM users WHERE email LIKE '%@gmail.com'",
+      hints: ["Use LIKE operator", "% is a wildcard", "Place % at the start to match ending"]
+    },
+    {
+      id: 10,
+      question: "Limit results",
+      description: "Write a SQL query to select the first 10 users ordered by created_at",
+      testString: "users table: id, name, email, created_at",
+      correctAnswer: "SELECT * FROM users ORDER BY created_at LIMIT 10",
+      hints: ["Use LIMIT clause", "ORDER BY comes before LIMIT", "LIMIT goes at the end"]
+    }
+  ],
+  hard: [
+    {
+      id: 11,
+      question: "Subquery in WHERE",
+      description: "Write a SQL query to find users who have placed more than 5 orders",
+      testString: "users(id, name) orders(id, user_id, total)",
+      correctAnswer: "SELECT * FROM users WHERE id IN (SELECT user_id FROM orders GROUP BY user_id HAVING COUNT(*) > 5)",
+      hints: ["Use subquery with IN", "GROUP BY user_id in subquery", "Use HAVING for aggregate conditions"]
+    },
+    {
+      id: 12,
+      question: "Left join with condition",
+      description: "Write a SQL query to show all users and their orders (if any), including users with no orders",
+      testString: "users(id, name) orders(id, user_id, total)",
+      correctAnswer: "SELECT * FROM users LEFT JOIN orders ON users.id = orders.user_id",
+      hints: ["Use LEFT JOIN", "LEFT JOIN includes all rows from left table", "ON specifies join condition"]
+    },
+    {
+      id: 13,
+      question: "Window function",
+      description: "Write a SQL query to show each order with a running total of amounts using ROW_NUMBER",
+      testString: "orders table: id, user_id, amount, created_at",
+      correctAnswer: "SELECT *, ROW_NUMBER() OVER (ORDER BY created_at) FROM orders",
+      hints: ["Use ROW_NUMBER() window function", "OVER clause defines the window", "ORDER BY inside OVER"]
+    },
+    {
+      id: 14,
+      question: "Common Table Expression (CTE)",
+      description: "Write a SQL query using WITH to create a CTE named 'recent_orders' for orders from last 30 days, then select from it",
+      testString: "orders table: id, user_id, total, created_at",
+      correctAnswer: "WITH recent_orders AS (SELECT * FROM orders WHERE created_at > CURRENT_DATE - INTERVAL '30 days') SELECT * FROM recent_orders",
+      hints: ["Start with WITH", "Name the CTE before AS", "Select from CTE name at the end"]
+    },
+    {
+      id: 15,
+      question: "Complex aggregation",
+      description: "Write a SQL query to find the average order total per user, only for users with more than 3 orders",
+      testString: "orders table: id, user_id, total",
+      correctAnswer: "SELECT user_id, AVG(total) FROM orders GROUP BY user_id HAVING COUNT(*) > 3",
+      hints: ["Use AVG() for average", "GROUP BY user_id", "HAVING filters groups after aggregation"]
+    }
+  ]
+};
+
 export const regexChallenges = {
   easy: [
     {

--- a/src/utils/sqlExecutor.js
+++ b/src/utils/sqlExecutor.js
@@ -1,0 +1,122 @@
+import { newDb } from 'pg-mem';
+import { Buffer } from 'buffer';
+
+// Polyfill Buffer for browser environment
+if (typeof window !== 'undefined') {
+  window.Buffer = Buffer;
+}
+
+/**
+ * Executes a SQL query against an in-memory PostgreSQL database
+ * @param {string} setupSQL - SQL statements to set up the database schema and data
+ * @param {string} query - The user's SQL query to execute
+ * @returns {Object} - { success: boolean, data: Array|null, error: string|null }
+ */
+export function executeSQLQuery(setupSQL, query) {
+  try {
+    // Create a new in-memory database
+    const db = newDb();
+
+    // Execute setup SQL to create tables and insert data
+    if (setupSQL) {
+      db.public.many(setupSQL);
+    }
+
+    // Execute the user's query
+    const result = db.public.many(query);
+
+    return {
+      success: true,
+      data: result,
+      error: null
+    };
+  } catch (error) {
+    return {
+      success: false,
+      data: null,
+      error: error.message || 'Unknown error occurred'
+    };
+  }
+}
+
+/**
+ * Compares two query results to see if they match
+ * @param {Array} result1 - First query result
+ * @param {Array} result2 - Second query result
+ * @returns {boolean} - True if results match, false otherwise
+ */
+export function compareResults(result1, result2) {
+  if (!result1 || !result2) return false;
+  if (result1.length !== result2.length) return false;
+
+  // Convert results to JSON for deep comparison
+  // Sort to handle different ordering (unless ORDER BY is specified)
+  const normalize = (arr) => {
+    return arr.map(row => {
+      // Convert to plain object and sort keys
+      const obj = {};
+      Object.keys(row).sort().forEach(key => {
+        // Handle numeric values that might have slight precision differences
+        if (typeof row[key] === 'number') {
+          obj[key] = Math.round(row[key] * 100) / 100;
+        } else {
+          obj[key] = row[key];
+        }
+      });
+      return obj;
+    });
+  };
+
+  const normalized1 = normalize(result1);
+  const normalized2 = normalize(result2);
+
+  // Compare each row
+  for (let i = 0; i < normalized1.length; i++) {
+    const row1 = normalized1[i];
+    const row2 = normalized2[i];
+
+    // Compare keys
+    const keys1 = Object.keys(row1).sort();
+    const keys2 = Object.keys(row2).sort();
+
+    if (keys1.length !== keys2.length) return false;
+    if (!keys1.every((key, idx) => key === keys2[idx])) return false;
+
+    // Compare values
+    for (const key of keys1) {
+      if (row1[key] !== row2[key]) return false;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * Formats query results for display
+ * @param {Array} data - Query result data
+ * @returns {string} - Formatted string representation
+ */
+export function formatResults(data) {
+  if (!data || data.length === 0) {
+    return 'No results returned';
+  }
+
+  // Get column names from first row
+  const columns = Object.keys(data[0]);
+
+  // Create header
+  let output = columns.join(' | ') + '\n';
+  output += columns.map(() => '---').join(' | ') + '\n';
+
+  // Add rows
+  data.forEach(row => {
+    output += columns.map(col => {
+      const val = row[col];
+      if (val === null) return 'NULL';
+      if (typeof val === 'object') return JSON.stringify(val);
+      return String(val);
+    }).join(' | ') + '\n';
+  });
+
+  return output;
+}


### PR DESCRIPTION
## Summary
- Added 15 PostgreSQL quiz challenges (5 easy, 5 medium, 5 hard)
- Implemented quiz type selection on home page (Regex vs PostgreSQL)
- Updated routing to support quiz type parameter (/quiz/:quizType/:difficulty)
- Enhanced Quiz component to handle both regex and SQL query validation
- Added SQL normalization for flexible answer matching (case-insensitive, whitespace-agnostic)
- Updated UI with dynamic labels and input fields based on quiz type
- PostgreSQL questions cover: SELECT, WHERE, JOINs, GROUP BY, aggregations, subqueries, CTEs, and window functions

## Changes Made

### New Files/Updates
- **src/data/challenges.js**: Added `postgresqlChallenges` with 15 questions across 3 difficulty levels
- **src/components/Home.js**: Added quiz type toggle buttons and dynamic content based on selection
- **src/App.js**: Updated route to accept `:quizType` parameter
- **src/components/Quiz.js**: 
  - Import both challenge types
  - Added SQL normalization function
  - Conditional logic for regex vs SQL validation
  - Dynamic UI labels (Test String vs Tables, Regex Pattern vs SQL Query)
  - Text input for regex, textarea for SQL queries

## Test Plan
- [x] Verify home page shows quiz type selection buttons
- [x] Verify clicking Regex/PostgreSQL updates difficulty card descriptions
- [x] Test Easy PostgreSQL quiz: all 5 questions load correctly
- [ ] Test Medium PostgreSQL quiz: JOINs and GROUP BY questions work
- [ ] Test Hard PostgreSQL quiz: subqueries, CTEs, window functions work
- [x] Verify SQL normalization accepts queries with different spacing/casing
- [x] Verify hints display correctly for PostgreSQL questions
- [x] Verify results page shows correct score after completing quiz
- [x] Verify Regex quizzes still work as before (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)